### PR TITLE
Fix default params for quering REST API

### DIFF
--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -26,7 +26,7 @@ const apiParamKeysOverwrites: Record<string, string> = {
 };
 
 export const apiDefaultParams: Record<string, string> = {
-  school_type_generalised: 'szkoła ponadpodstawowa',
+  school_type: 'liceum ogólnokształcące|technikum|szkoła branżowa I stopnia',
   ordering: 'school_name',
 };
 


### PR DESCRIPTION
In [PR 34 (warsawlo-django repo)](https://github.com/WarsawLO/warsawlo-django/pull/34) `school_type_generalized` field was removed.